### PR TITLE
Fix broken notebook link

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -43,7 +43,7 @@
     "* cuDF (1 hr)\n",
     "  * [Intro to cuDF notebook](./cudf/Intro%20to%20cuDF.ipynb) (20 min)\n",
     "    * Exercises in notebook (10 min)\n",
-    "  * [cuDF User Defined Functions notebook](./cudf/cuDF%20UDF.ipynb) (20 min)\n",
+    "  * [cuDF User Defined Functions notebook](./cudf/Intro%20to%20cuDF%20UDFs.ipynb) (20 min)\n",
     "    * Exercises in notebook (10 min)\n",
     "  * case study notebooks..."
    ]


### PR DESCRIPTION
Enjoying the tutorial!

As I was working through `index.ipynb`, I thought the cuDF UDF notebook might be missing, but it was just that the link did not point to the correct location (the notebook might've been renamed). This fixes the link.